### PR TITLE
Add Atom feed

### DIFF
--- a/site.hs
+++ b/site.hs
@@ -25,8 +25,17 @@ main = hakyll $ do
         route $ setExtension "html"
         compile $ pandocCompiler
             >>= loadAndApplyTemplate "templates/post.html"    postCtx
+            >>= saveSnapshot "content"
             >>= loadAndApplyTemplate "templates/default.html" postCtx
             >>= relativizeUrls
+
+    create ["atom.xml"] $ do
+        route idRoute
+        compile $ do
+            posts <- fmap (take 10) . recentFirst =<<
+                loadAllSnapshots "posts/*" "content"
+            renderAtom feedConfiguration feedCtx posts
+
 
     create ["archive.html"] $ do
         route idRoute
@@ -69,3 +78,15 @@ postCtx :: Context String
 postCtx =
     dateField "date" "%B %e, %Y" `mappend`
     defaultContext
+
+feedCtx :: Context String
+feedCtx = defaultContext
+
+feedConfiguration :: FeedConfiguration
+feedConfiguration = FeedConfiguration
+    { feedTitle = "Richard's Software Blog"
+    , feedDescription = "Richar's Software Blog"
+    , feedAuthorName = "Richard Marmorstein"
+    , feedAuthorEmail = "nobody@example.com"
+    , feedRoot = "https://twitchard.github.io"
+    }

--- a/templates/default.html
+++ b/templates/default.html
@@ -9,6 +9,7 @@
         <meta name="twitter:title" content="$title$" />
         <meta name="twitter:description" content="$description$" />
         <title>$title$ - Richard Marmorstein</title>
+        <link rel="alternate" type="application/atom+xml" href="/atom.xml">
         <link rel="stylesheet" href="/css/default.css" />
         <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">
         <!-- Global site tag (gtag.js) - Google Analytics -->


### PR DESCRIPTION
Hey, after recently finding your blog and wanting to subscribe to it via RSS/Atom, and finding neither, I threw together this PR in order to fix that. :)

Relevant resources on how this was done:
* <https://jaspervdj.be/hakyll/tutorials/05-snapshots-feeds.html>
* <https://dri.es/rss-auto-discovery>, <https://www.intertwingly.net/wiki/pie/AutoDiscovery>

Though do note that in `site.hs` I specified a dummy email address which Hakyll for some reason requires, even though Atom does not. Feel free to change it, even though leaving it as-is seems like it should also be fine since I don't think any feed readers do anything useful with that.