### PR TITLE
Add post: Software's Centaur Era

### DIFF
--- a/posts/2026-05-18-softwares-centaur-era.md
+++ b/posts/2026-05-18-softwares-centaur-era.md
@@ -1,0 +1,25 @@
+---
+title: "Software's Centaur Era"
+draft: false
+class: prose
+description: "Will AI automate away all the software jobs? Not until humans have nothing left to contribute -- and that era hasn't even begun."
+quote: "We're not over until the Centaur Era is over, and it hasn't even really begun yet"
+---
+
+<img src="../images/dropCapI.jpg" class="dropCap" alt="I" />*t's 2030. I wake up, make my coffee, drag myself over to my laptop. Then I remember -- AI has completely replaced knowledge work. I open up my agent chat, type* "still got access to my bank account? Please continue making money." *I hesitate, briefly considering typing something else. Maybe influence the AI's direction toward an area of my own particular interest? But of course, as that would constitute knowledge work (which AI has entirely replaced), it would strictly decrease my expected return. I press enter, and scratch that itch instead by starting Wordle with something other than SLATE. I solve in 5, finish my coffee, and then get to work at my side gig: driving around doing TaskRabbit jobs at the behest of AIs that are not (yet) otherwise capable of influencing the physical world.*
+
+...
+
+There was a teenager on r/programming asking about whether they should go to college and major in computer science. They were worried -- is AI going to automate away all the software jobs? I went back to my alma mater -- a small (beautiful) Liberal Arts college in Virginia -- a few weeks ago and was visiting with one of my computer science professors. She told me the major was shrinking, presumably also because of AI fears.
+
+Will AI automate away all the software jobs?
+
+I think it's easy to miss what this actually means, economically speaking. Software jobs don't necessarily disappear if AI surpasses humans at writing software -- the jobs might *change in nature*, but they don't disappear. The software jobs only really disappear when there is really *nothing left for humans to contribute to the process*.
+
+Take chess. Deep Blue beat Kasparov in 1997, but for a long period of time after that, the best chess performance didn't come from engines playing by themselves -- it came from "centaurs" -- a colorful term for a team comprised of *a skilled human wielding a chess engine*. Now the centaur era of chess is over -- the best engines are so good that a grandmaster steering them only weakens them -- but the centaur era lasted for decades.
+
+Is the software industry in its centaur era right now? No. Not even. Deep Blue hasn't even beaten Kasparov yet.
+
+You can hire a grandmaster-level software engineer, leave them pretty much alone, and trust that they will start making valuable contributions to long-term projects and will reliably be making your software system better. That's just not true (yet) of any of these coding agents. If you leave them alone without human steering, they go off the rails pretty quickly. If you just set an AI coding agent (and an AI reviewer) loose with your product roadmap and let them merge things, your codebase (and product) gets real broken, real quick. Claude built [its vibe-coded C compiler](https://www.infoq.com/news/2026/02/claude-built-c-compiler/), Cursor built [their vibe-coded browser](https://fortune.com/2026/01/23/cursor-built-web-browser-with-swarm-ai-agents-powered-openai/) -- it's true. But being able to reliably make independent progress on long-horizon projects? This is the economic core of why software engineers are valuable. And it is the absolute frontier of what these models are just beginning to become capable of.
+
+But even if coding agents nail it, and become able to reliably improve software, it's not over for the humans. As long as humans have something to contribute -- as long as teams of humans and agents working *together* are more effective than teams of agents alone, there will always be room for humans in the software industry. We're not over until the Centaur Era is over, and it hasn't even really begun yet.


### PR DESCRIPTION
Adds a new post, "Software's Centaur Era", arguing that software jobs only disappear once humans have nothing left to contribute -- and that the centaur era hasn't even begun.

- Drop cap on the opening "I"
- Fixed obvious typos/errors: "Deep blue" -> "Deep Blue", "it's" -> "its", "long-horizen" -> "long-horizon", "valuabl" -> "valuable", "hasn't even beat" -> "hasn't even beaten", number agreement on "steering them weakens it"
- Added links to articles about Claude's C compiler and Cursor's browser

https://claude.ai/code/session_01Ms3sbmjuUVKE556F3tFN1v

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ms3sbmjuUVKE556F3tFN1v)_